### PR TITLE
orthonormalize ground truth data to plot against GPFA model predictions

### DIFF
--- a/core_gpfa/postprocess.py
+++ b/core_gpfa/postprocess.py
@@ -3,7 +3,7 @@
 import numpy as np
 from core_gpfa.exact_inference_with_LL import exact_inference_with_LL
 
-def orthogonalize(X, C):
+def orthogonalize(X, C, full_mat=False):
     """
     X_orth: orthonormalized latent variables (x_dim x T)
     C_orth: orthonormalized loading matrix (y_dim x x_dim)
@@ -16,7 +16,7 @@ def orthogonalize(X, C):
         C_orth = C / TT
         X_orth = np.matmul(TT, X)
     else:
-        UU, DD, Vh = np.linalg.svd(C, full_matrices=False) # TODO check thin svd
+        UU, DD, Vh = np.linalg.svd(C, full_matrices=full_mat) # TODO check thin svd
         DD = np.diag(DD)
         VV = Vh.T
         # (UU, DD, VV) = svd(C, 0)
@@ -43,7 +43,7 @@ def segment_by_trial(seq, X, fn):
 
     return seq
 
-def postprocess(est_params, seq_train, seq_test, method, kern_SD):
+def postprocess(est_params, seq_train, seq_test, method):
     if method=='gpfa':
         C = est_params.C
         X  = np.concatenate([np.array(trial.xsm) for trial in seq_train], 1)

--- a/example.py
+++ b/example.py
@@ -55,8 +55,7 @@ result = extract_traj(output_dir=OUTPUT_DIR, data=dat, method=method, x_dim=x_di
 
 # Orthonormalize trajectories
 # Returns results for the last run cross-validation fold, if enabled
-(est_params, seq_train, seq_test) = postprocess(result['params'], result['seq_train'],\
-                                                 result['seq_test'], method, kern_SD)
+(est_params, seq_train, seq_test) = postprocess(result['params'], result['seq_train'], result['seq_test'], method)
 
 print("LL for training: %.4f, for testing: %.4f, method: %s, x_dim:%d, param_cov_type:%s, param_Q:%d"\
          % (result['LLtrain'], result['LLtest'], method, x_dim, param_cov_type, param_Q))
@@ -84,7 +83,7 @@ if len(seq_test)>0:
     # # Plot each dimension of trajectory, test data
     # plot_1d(seq_test, 'x_orth', result['bin_width'])
     # Change to 'x_orth' to plot orthogonalized trajectories
-    plot_1d_error(seq_test, 'xsm', result['bin_width'], output_file=output_file)
+    plot_1d_error(seq_test, 'x_orth', result['bin_width'], output_file=output_file)
 
 # Plot all figures
 plt.show()


### PR DESCRIPTION
The output of GPFA is a random rotation of the true latent data, so plotting this output against the ground truth (as in plot_1d_error) isn't visually meaningful. The changes in this commit orthonormalize the ground truth data and plot these linearly transformed data against the orthonormalized GPFA output to show a visual match between the two.